### PR TITLE
make Slack Display Name and User Icon be configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>in.ashwanthkumar</groupId>
     <artifactId>gocd-slack-notifier</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -72,6 +72,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
                 <configuration>
                     <source>1.5</source>
                     <target>1.5</target>
@@ -89,7 +90,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.outputDirectory}\lib</outputDirectory>
+                            <outputDirectory>${project.build.outputDirectory}/lib</outputDirectory>
                             <includeScope>runtime</includeScope>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>

--- a/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationPlugin.java
@@ -42,12 +42,10 @@ public class GoNotificationPlugin implements GoPlugin {
         rules = RulesReader.read(pluginConfig);
     }
 
-    @Override
     public void initializeGoApplicationAccessor(GoApplicationAccessor goApplicationAccessor) {
         // ignore
     }
 
-    @Override
     public GoPluginApiResponse handle(GoPluginApiRequest goPluginApiRequest) {
         if (goPluginApiRequest.requestName().equals(REQUEST_NOTIFICATIONS_INTERESTED_IN)) {
             return handleNotificationsInterestedIn();
@@ -57,7 +55,6 @@ public class GoNotificationPlugin implements GoPlugin {
         return null;
     }
 
-    @Override
     public GoPluginIdentifier pluginIdentifier() {
         return new GoPluginIdentifier(EXTENSION_TYPE, goSupportedVersions);
     }

--- a/src/main/java/in/ashwanthkumar/gocd/slack/SlackPipelineListener.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/SlackPipelineListener.java
@@ -24,9 +24,8 @@ public class SlackPipelineListener extends PipelineListener {
         slack = new Slack(rules.getWebHookUrl());
         updateSlackChannel(rules.getSlackChannel());
 
-        // TODO - Make these configurable
-        slack.displayName("gocd-slack-bot")
-                .icon("https://raw.githubusercontent.com/ashwanthkumar/assets/c597777ee749c89fec7ce21304d727724a65be7d/images/gocd-logo.png");
+        slack.displayName(rules.getSlackDisplayName())
+            .icon(rules.getSlackUserIcon());
     }
 
     @Override

--- a/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/Rules.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/Rules.java
@@ -14,8 +14,10 @@ import static in.ashwanthkumar.gocd.slack.ruleset.PipelineRule.merge;
 
 public class Rules {
     private boolean enabled;
-    private String slackChannel;
     private String webHookUrl;
+    private String slackChannel;
+    private String slackDisplayName;
+    private String slackUserIconURL;
     private String goServerHost;
     private String goLogin;
     private String goPassword;
@@ -32,6 +34,15 @@ public class Rules {
         return this;
     }
 
+    public String getWebHookUrl() {
+        return webHookUrl;
+    }
+
+    public Rules setWebHookUrl(String webHookUrl) {
+        this.webHookUrl = webHookUrl;
+        return this;
+    }
+
     public String getSlackChannel() {
         return slackChannel;
     }
@@ -41,12 +52,21 @@ public class Rules {
         return this;
     }
 
-    public String getWebHookUrl() {
-        return webHookUrl;
+    public String getSlackDisplayName() {
+        return slackDisplayName;
     }
 
-    public Rules setWebHookUrl(String webHookUrl) {
-        this.webHookUrl = webHookUrl;
+    private Rules setSlackDisplayName(String displayName) {
+        this.slackDisplayName = displayName;
+        return this;
+    }
+
+    public String getSlackUserIcon() {
+        return slackUserIconURL;
+    }
+
+    private Rules setSlackUserIcon(String iconURL) {
+        this.slackUserIconURL = iconURL;
         return this;
     }
 
@@ -92,7 +112,6 @@ public class Rules {
 
     public Option<PipelineRule> find(final String pipeline, final String stage, final String pipelineStatus) {
         return Lists.find(pipelineRules, new Predicate<PipelineRule>() {
-            @Override
             public Boolean apply(PipelineRule input) {
                 return input.matches(pipeline, stage, pipelineStatus);
             }
@@ -101,11 +120,23 @@ public class Rules {
 
     public static Rules fromConfig(Config config) {
         boolean isEnabled = config.getBoolean("enabled");
+
+        String webhookUrl = config.getString("webhookUrl");
         String channel = null;
         if (config.hasPath("channel")) {
             channel = config.getString("channel");
         }
-        String webhookUrl = config.getString("webhookUrl");
+
+        String displayName = "gocd-slack-bot";
+        if(config.hasPath("slackDisplayName")) {
+            displayName = config.getString("slackDisplayName");
+        }
+
+        String iconURL = "https://raw.githubusercontent.com/ashwanthkumar/assets/c597777ee749c89fec7ce21304d727724a65be7d/images/gocd-logo.png";
+        if(config.hasPath("slackUserIconURL")) {
+            iconURL = config.getString("slackUserIconURL");
+        }
+
         String serverHost = config.getString("server-host");
         String login = null;
         if (config.hasPath("login")) {
@@ -119,7 +150,6 @@ public class Rules {
         final PipelineRule defaultRule = PipelineRule.fromConfig(config.getConfig("default"), channel);
 
         List<PipelineRule> pipelineRules = Lists.map((List<Config>) config.getConfigList("pipelines"), new Function<Config, PipelineRule>() {
-            @Override
             public PipelineRule apply(Config input) {
                 return merge(PipelineRule.fromConfig(input), defaultRule);
             }
@@ -127,8 +157,10 @@ public class Rules {
 
         Rules rules = new Rules()
                 .setEnabled(isEnabled)
-                .setSlackChannel(channel)
                 .setWebHookUrl(webhookUrl)
+                .setSlackChannel(channel)
+                .setSlackDisplayName(displayName)
+                .setSlackUserIcon(iconURL)
                 .setPipelineRules(pipelineRules)
                 .setGoServerHost(serverHost)
                 .setGoLogin(login)

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -2,7 +2,7 @@
 <go-plugin id="slack.notifier" version="1">
     <about>
         <name>Slack Notification Plugin</name>
-        <version>0.1</version>
+        <version>1.1</version>
         <target-go-version>15.1.0</target-go-version>
         <description>Plugin to send build notifications to slack</description>
         <vendor>


### PR DESCRIPTION
Per the //TODO on SlackPipelineListener.java:27, the display name and avatar/icon are now configurable

Previous hardcoded values are still the defaults.

Also included a minor version bump since this is new functionality.
