### PR TITLE
"Building" message should be triggerable

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -xe
+rm -rf dist/
+mkdir dist
+
+mvn clean package
+cp target/gocd-slack-notifier*.jar dist/

--- a/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationMessage.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationMessage.java
@@ -168,9 +168,14 @@ public class GoNotificationMessage {
 
     public void tryToFixStageResult(Rules rules)
     {
+        String currentStatus = pipeline.stage.state.toUpperCase();
+        String currentResult = pipeline.stage.result.toUpperCase();
+        if (currentStatus.equals("BUILDING") && currentResult.equals("UNKNOWN")) {
+            pipeline.stage.result = "BUILDING";
+            return;
+        }
         // We only need to double-check certain messages; the rest are
         // trusty-worthy.
-        String currentResult = pipeline.stage.result.toUpperCase();
         if (!currentResult.equals("PASSED") && !currentResult.equals("FAILED"))
             return;
 

--- a/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationPlugin.java
@@ -76,6 +76,7 @@ public class GoNotificationPlugin implements GoPlugin {
             LOGGER.info(message.fullyQualifiedJobName() + " has " + message.getStageState() + "/" + message.getStageResult());
             rules.getPipelineListener().notify(message);
         } catch (Exception e) {
+            LOGGER.error("Error handling status message", e);
             responseCode = INTERNAL_ERROR_RESPONSE_CODE;
             response.put("status", "failure");
             if (!isEmpty(e.getMessage())) {

--- a/src/main/java/in/ashwanthkumar/gocd/slack/PipelineListener.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/PipelineListener.java
@@ -16,6 +16,7 @@ abstract public class PipelineListener {
 
     public void notify(GoNotificationMessage message) throws Exception {
         message.tryToFixStageResult(rules);
+        LOG.debug(String.format("Finding rules with state %s", message.getStageResult()));
         Option<PipelineRule> ruleOption = rules.find(message.getPipelineName(), message.getStageName(), message.getStageResult());
         if (ruleOption.isDefined()) {
             PipelineRule pipelineRule = ruleOption.get();

--- a/src/main/java/in/ashwanthkumar/gocd/slack/SlackPipelineListener.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/SlackPipelineListener.java
@@ -106,6 +106,7 @@ public class SlackPipelineListener extends PipelineListener {
     }
 
     private void updateSlackChannel(String slackChannel) {
+        LOG.debug(String.format("Updating target slack channel to %s", slackChannel));
         // by default post it to where ever the hook is configured to do so
         if (startsWith(slackChannel, "#")) {
             slack.sendToChannel(slackChannel.substring(1));

--- a/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/PipelineRule.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/PipelineRule.java
@@ -22,7 +22,7 @@ public class PipelineRule {
     public PipelineRule(PipelineRule copy) {
         this.nameRegex = copy.nameRegex;
         this.stageRegex = copy.stageRegex;
-        this.channel = copy.stageRegex;
+        this.channel = copy.channel;
         this.status = copy.status;
     }
 


### PR DESCRIPTION
Hello!

When I tried out the slack notifier, I noticed that it did not report the "building" status in slack as advertised. This is because "BUILDING" is a pipeline state and not a pipeline result.

This PR follows the example in `tryToFixStageResult` to make the `result` be `BUILDING`.

I also added a release.sh script that I copied from a different plugin so that other noobs like me don't have to figure out how to package the jar.
