### PR TITLE
Fix case where non-last stage in multi-stage pipeline fails

### DIFF
--- a/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationMessage.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationMessage.java
@@ -194,8 +194,13 @@ public class GoNotificationMessage {
         // Figure out whether the previous stage passed or failed.
         JsonArray stages = previous.get("stages").getAsJsonArray();
         JsonObject lastStage = stages.get(stages.size() - 1).getAsJsonObject();
-        String previousResult = lastStage.get("result").getAsString()
-            .toUpperCase();
+
+        String previousResult = "";
+        // If a multi-stage pipeline fails at not-the-last stage, then the last
+        // stage will not have run, and its result will be null
+        if (lastStage.get("result") != null) {
+            previousResult = lastStage.get("result").getAsString().toUpperCase();
+        }
 
         // Fix up our build status.  This is slightly asymmetrical, because
         // we want to be quicker to praise than to blame.  Also, I _think_


### PR DESCRIPTION
This addresses the following stacktrace that is produced when a multistage pipeline fails on the non-last stage, and then is rerun. (On re-run, the plugin successfully notifies for "BULDING", but not for "PASSED/FAILED".)

```
2015-08-28 14:29:30,844  INFO [66@MessageListener for PluginNotificationListener] GoNotificationPlugin:52 - til/24/cat/1 has Building/Unknown
2015-08-28 14:29:48,807  INFO [66@MessageListener for PluginNotificationListener] GoNotificationPlugin:52 - til/24/cat/1 has Failed/Failed
2015-08-28 14:29:49,437 ERROR [66@MessageListener for PluginNotificationListener] GoNotificationPlugin:77 - Error handling status message
java.lang.NullPointerException
        at in.ashwanthkumar.gocd.slack.GoNotificationMessage.tryToFixStageResult(GoNotificationMessage.java:205)
        at in.ashwanthkumar.gocd.slack.PipelineListener.notify(PipelineListener.java:18)
        at in.ashwanthkumar.gocd.slack.GoNotificationPlugin.handleStageNotification(GoNotificationPlugin.java:77)
        at in.ashwanthkumar.gocd.slack.GoNotificationPlugin.handle(GoNotificationPlugin.java:53)
        at com.thoughtworks.go.plugin.infra.DefaultPluginManager$1.execute(DefaultPluginManager.java:172)
        at com.thoughtworks.go.plugin.infra.DefaultPluginManager$1.execute(DefaultPluginManager.java:167)
        at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.executeActionOnTheService(FelixGoPluginOSGiFramework.java:315)
        at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.doOn(FelixGoPluginOSGiFramework.java:245)
        at com.thoughtworks.go.plugin.infra.DefaultPluginManager.submitTo(DefaultPluginManager.java:167)
        at com.thoughtworks.go.plugin.access.PluginRequestHelper.submitRequest(PluginRequestHelper.java:32)
        at com.thoughtworks.go.plugin.access.notification.NotificationExtension.notify(NotificationExtension.java:74)
        at com.thoughtworks.go.server.messaging.plugin.PluginNotificationService.notifyPlugin(PluginNotificationService.java:61)
        at com.thoughtworks.go.server.messaging.plugin.PluginNotificationService.notifyPlugins(PluginNotificationService.java:53)
        at com.thoughtworks.go.server.messaging.plugin.PluginNotificationListener.onMessage(PluginNotificationListener.java:30)
        at com.thoughtworks.go.server.messaging.plugin.PluginNotificationListener.onMessage(PluginNotificationListener.java:21)
        at com.thoughtworks.go.server.messaging.activemq.JMSMessageListenerAdapter.runImpl(JMSMessageListenerAdapter.java:65)
        at com.thoughtworks.go.server.messaging.activemq.JMSMessageListenerAdapter.run(JMSMessageListenerAdapter.java:50)
        at java.lang.Thread.run(Thread.java:745)
```

Relatedly, it would be pretty cool to get https://github.com/ashwanthkumar/gocd-slack-build-notifier/pull/15 merged since the "FIXED/BROKEN" functionality doesn't really work as expected in master.
