### PR TITLE
Add handling of plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,13 @@
             <version>1.2.1</version>
         </dependency>
 
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationPlugin.java
@@ -20,7 +20,6 @@ import static java.util.Arrays.asList;
 
 @Extension
 public class GoNotificationPlugin implements GoPlugin {
-    public static final String CONFIG_VIEW_TEMPLATE = "<div class=\"form_item_block\"><label>Message:</label></div>";
     private static Logger LOGGER = Logger.getLoggerFor(GoNotificationPlugin.class);
 
     public static final String EXTENSION_TYPE = "notification";

--- a/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationPlugin.java
@@ -10,14 +10,17 @@ import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import in.ashwanthkumar.gocd.slack.ruleset.Rules;
 import in.ashwanthkumar.gocd.slack.ruleset.RulesReader;
+import org.apache.commons.io.IOUtils;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.*;
 
 import static java.util.Arrays.asList;
 
 @Extension
 public class GoNotificationPlugin implements GoPlugin {
+    public static final String CONFIG_VIEW_TEMPLATE = "<div class=\"form_item_block\"><label>Message:</label></div>";
     private static Logger LOGGER = Logger.getLoggerFor(GoNotificationPlugin.class);
 
     public static final String EXTENSION_TYPE = "notification";
@@ -25,6 +28,9 @@ public class GoNotificationPlugin implements GoPlugin {
 
     public static final String REQUEST_NOTIFICATIONS_INTERESTED_IN = "notifications-interested-in";
     public static final String REQUEST_STAGE_STATUS = "stage-status";
+    public static final String REQUEST_GET_CONFIGURATION = "go.plugin-settings.get-configuration";
+    public static final String REQUEST_GET_VIEW = "go.plugin-settings.get-view";
+    public static final String REQUEST_VALIDATE_CONFIGURATION = "go.plugin-settings.validate-configuration";
 
     public static final int SUCCESS_RESPONSE_CODE = 200;
     public static final int INTERNAL_ERROR_RESPONSE_CODE = 500;
@@ -47,16 +53,55 @@ public class GoNotificationPlugin implements GoPlugin {
     }
 
     public GoPluginApiResponse handle(GoPluginApiRequest goPluginApiRequest) {
-        if (goPluginApiRequest.requestName().equals(REQUEST_NOTIFICATIONS_INTERESTED_IN)) {
+        String requestName = goPluginApiRequest.requestName();
+        if (requestName.equals(REQUEST_NOTIFICATIONS_INTERESTED_IN)) {
             return handleNotificationsInterestedIn();
-        } else if (goPluginApiRequest.requestName().equals(REQUEST_STAGE_STATUS)) {
+        } else if (requestName.equals(REQUEST_STAGE_STATUS)) {
             return handleStageNotification(goPluginApiRequest);
+        } else if (requestName.equals(REQUEST_GET_VIEW)) {
+            return handleRequestGetView();
+        } else if (requestName.equals(REQUEST_VALIDATE_CONFIGURATION)) {
+            return handleValidateConfig(goPluginApiRequest.requestBody());
+        } else if (requestName.equals(REQUEST_GET_CONFIGURATION)) {
+            return handleRequestGetConfiguration();
         }
         return null;
     }
 
+    private GoPluginApiResponse handleValidateConfig(String requestBody) {
+        List<Object> response = Arrays.asList();
+        return renderJSON(SUCCESS_RESPONSE_CODE, response);
+    }
+
+
     public GoPluginIdentifier pluginIdentifier() {
         return new GoPluginIdentifier(EXTENSION_TYPE, goSupportedVersions);
+    }
+
+
+    private GoPluginApiResponse handleRequestGetView() {
+        Map<String, Object> response = new HashMap<String, Object>();
+
+        try {
+            String template = IOUtils.toString(getClass().getResourceAsStream("/views/config.template.html"), "UTF-8");
+            response.put("template", template);
+        } catch (IOException e) {
+            response.put("error", "Can't load view template");
+            return renderJSON(INTERNAL_ERROR_RESPONSE_CODE, response);
+        }
+
+
+        return renderJSON(SUCCESS_RESPONSE_CODE, response);
+    }
+
+    private GoPluginApiResponse handleRequestGetConfiguration() {
+        Map<String, Object> response = new HashMap<String, Object>();
+        Map<String, Object> serverUrlParams = new HashMap<String, Object>();
+        serverUrlParams.put("display-name", "External server URL");
+
+        response.put("server_url_external", serverUrlParams);
+
+        return renderJSON(SUCCESS_RESPONSE_CODE, response);
     }
 
     private GoPluginApiResponse handleNotificationsInterestedIn() {
@@ -99,7 +144,7 @@ public class GoNotificationPlugin implements GoPlugin {
     }
 
     private GoPluginApiResponse renderJSON(final int responseCode, Object response) {
-        final String json = response == null ? null : new GsonBuilder().create().toJson(response);
+        final String json = response == null ? null : new GsonBuilder().disableHtmlEscaping().create().toJson(response);
         return new GoPluginApiResponse() {
             @Override
             public int responseCode() {

--- a/src/main/resources/views/config.template.html
+++ b/src/main/resources/views/config.template.html
@@ -1,0 +1,4 @@
+<div class="form_item_block">
+    <label>External server URL:<span class="asterisk">*</span></label>
+    <input type="text" ng-model="server_url_external" ng-required="true">
+</div>

--- a/src/test/java/in/ashwanthkumar/gocd/slack/GoNotificationPluginTest.java
+++ b/src/test/java/in/ashwanthkumar/gocd/slack/GoNotificationPluginTest.java
@@ -1,0 +1,115 @@
+package in.ashwanthkumar.gocd.slack;
+
+
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import in.ashwanthkumar.gocd.slack.util.TestUtils;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GoNotificationPluginTest {
+
+    public static final String USER_HOME = "user.home";
+    public static final String REQUEST_GET_CONFIGURATION = "go.plugin-settings.get-configuration";
+    public static final String REQUEST_GET_VIEW = "go.plugin-settings.get-view";
+    public static final String REQUEST_NOTIFICATIONS_INTERESTED_IN = "notifications-interested-in";
+    public static final String REQUEST_VALIDATE_CONFIGURATION = "go.plugin-settings.validate-configuration";
+
+
+    public static final String NOTIFICATION_INTEREST_RESPONSE = "{\"notifications\":[\"stage-status\"]}";
+    public static final String GET_VIEW_RESPONSE = "{" +
+            "\"template\":\"" +
+            "<div class=\\\"form_item_block\\\">" +
+            "<label>Message:" +
+            "</label>" +
+            "</div>\"" +
+            "}";
+    public static final String GET_CONFIGURATION_RESPONSE = "{\"server_url_external\":{" +
+            "\"display-name\":\"External server URL\"" +
+            "}" +
+            "}";
+    private static final String GET_CONFIG_VALIDATION_RESPONSE = "[]";
+
+
+    @Test
+    public void canHandleConfigValidationRequest() {
+
+        GoNotificationPlugin plugin = createGoNotificationPlugin();
+
+        GoPluginApiRequest request = mock(GoPluginApiRequest.class);
+        when(request.requestName()).thenReturn(REQUEST_VALIDATE_CONFIGURATION);
+        when(request.requestBody()).thenReturn("{\"plugin-settings\":" +
+                "{\"external_server_url\":{\"value\":\"bob\"}}}");
+
+        GoPluginApiResponse rv = plugin.handle(request);
+
+        assertThat(rv, is(notNullValue()));
+        assertThat(rv.responseBody(), equalTo(GET_CONFIG_VALIDATION_RESPONSE));
+
+    }
+
+    @Test
+    public void canHandleConfigurationRequest() {
+
+        GoNotificationPlugin plugin = createGoNotificationPlugin();
+
+        GoPluginApiRequest request = mock(GoPluginApiRequest.class);
+        when(request.requestName()).thenReturn(REQUEST_GET_CONFIGURATION);
+
+        GoPluginApiResponse rv = plugin.handle(request);
+
+        assertThat(rv, is(notNullValue()));
+        assertThat(rv.responseBody(), equalTo(GET_CONFIGURATION_RESPONSE));
+
+    }
+
+    @Test
+    public void canHandleGetViewRequest() {
+
+        GoNotificationPlugin plugin = createGoNotificationPlugin();
+
+        GoPluginApiRequest request = mock(GoPluginApiRequest.class);
+        when(request.requestName()).thenReturn(REQUEST_GET_VIEW);
+
+        GoPluginApiResponse rv = plugin.handle(request);
+
+        assertThat(rv, is(notNullValue()));
+        assertThat(rv.responseBody(), containsString("<div class=\\\""));
+
+    }
+
+    @Test
+    public void canHandleNotificationInterestedInRequest() {
+
+        GoNotificationPlugin plugin = createGoNotificationPlugin();
+
+        GoPluginApiRequest request = mock(GoPluginApiRequest.class);
+        when(request.requestName()).thenReturn(REQUEST_NOTIFICATIONS_INTERESTED_IN);
+
+        GoPluginApiResponse rv = plugin.handle(request);
+
+        assertThat(rv, is(notNullValue()));
+        assertThat(rv.responseBody(), equalTo(NOTIFICATION_INTEREST_RESPONSE));
+
+    }
+
+    public static GoNotificationPlugin createGoNotificationPlugin() {
+        String folder = TestUtils.getResourceDirectory("go_notify.conf");
+
+        String oldUserHome = System.getProperty(USER_HOME);
+        System.setProperty(USER_HOME, folder);
+
+        GoNotificationPlugin plugin = new GoNotificationPlugin();
+
+        System.setProperty(USER_HOME, oldUserHome);
+        return plugin;
+    }
+
+}

--- a/src/test/java/in/ashwanthkumar/gocd/slack/util/TestUtils.java
+++ b/src/test/java/in/ashwanthkumar/gocd/slack/util/TestUtils.java
@@ -16,4 +16,9 @@ public class TestUtils {
         return factory;
     }
 
+    public static String getResourceDirectory(String resource) {
+        ClassLoader ldr = Thread.currentThread().getContextClassLoader();
+        String url = ldr.getResource(resource).toString();
+        return url.substring("file:".length(), url.lastIndexOf('/'));
+    }
 }

--- a/src/test/resources/go_notify.conf
+++ b/src/test/resources/go_notify.conf
@@ -1,0 +1,35 @@
+gocd.slack {
+  # feature flag for notification plugin, turning this false will not post anything to Slack
+  # quite useful while testing / debugging
+  enabled = true
+  # Global default channel for all pipelines, these can be overriden at a pipeline level as well
+  channel = "#gocd"
+  webhookUrl: "https://hooks.slack.com/services/abcd/efgh/lmnopqrst12345"       # Mandatory field
+  # Enter full FQDN of your GoCD instance. We'll be sending links on your slack channel using this as the base uri.
+  server-host = "http://localhost:8080/"
+
+  # Default settings for pipelines
+  default {
+    name = ".*"
+    stage = ".*"
+    # you can provide multiple values by separating them with | (pipe) symbol - failed|broken
+    state = "failed"        # accepted values - failed / broken / fixed / passed / all
+    #channel = "gocd"       # Mandatory field
+  }
+
+  # Example settings would be like
+  # pipelines = [{
+  #   nameRegex = "upc14"
+  #   channel = "#"
+  #   state = "failed|broken"
+  # }]
+  pipelines = [{
+    name = "gocd-slack-build-notifier"
+  }, {
+    name = "my-java-utils"
+    stage = "build"
+    # you can provide multiple values by separating them with | (pipe) symbol - failed|broken
+    state = "failed"        # accepted values - failed / broken / fixed / passed / all
+    channel = "#gocd-build"       # Mandatory field
+  }]
+}


### PR DESCRIPTION
Go version 16.1.0 expects plugins to follow configuration protocol,  which is described here https://developer.go.cd/current/writing_go_plugins/plugin_settings/version_1_0/plugin_settings_configuration.html

In current version the plugins that don't follow this protocol generate errors like the one below.  Most likely in the future they will stop to function.  This pull request implements minimal requirements for config protocol.  This could could be used as jump start to fix #25 and #11

```
Java.lang.RuntimeException: Interaction with plugin with id 'yum' implementing 'package-repository' extension failed while requesting for 'go.plugin-settings.get-configuration'. Reason: [The plugin sent a response that could not be understood by Go. Plugin returned with code '400' and the following response: 'Invalid request name go.plugin-settings.get-configuration']
    at com.thoughtworks.go.plugin.access.PluginRequestHelper.submitRequest(PluginRequestHelper.java:38)
    at com.thoughtworks.go.plugin.access.common.settings.AbstractExtension.getPluginSettingsConfiguration(AbstractExtension.java:45)
    at com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExtension.getPluginSettingsConfiguration(PackageAsRepositoryExtension.java:51)
    at com.thoughtworks.go.plugin.access.common.settings.PluginSettingsMetadataLoader.fetchPluginSettingsMetaData(PluginSettingsMetadataLoader.java:63)
    at com.thoughtworks.go.plugin.access.common.settings.PluginSettingsMetadataLoader.pluginLoaded(PluginSettingsMetadataLoader.java:47)
    at com.thoughtworks.go.plugin.infra.DefaultPluginManager$FilterChangeListener.pluginLoaded(DefaultPluginManager.java:262)
    at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework$2.execute(FelixGoPluginOSGiFramework.java:353)
    at org.apache.commons.collections.CollectionUtils.forAllDo(CollectionUtils.java:389)
    at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.getBundle(FelixGoPluginOSGiFramework.java:111)
    at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.loadPlugin(FelixGoPluginOSGiFramework.java:97)
    at com.thoughtworks.go.plugin.infra.listeners.DefaultPluginJarChangeListener.refreshBundle(DefaultPluginJarChangeListener.java:152)
```
