### PR TITLE
add optional api server host

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ gocd.slack {
   login = "someuser"
   password = "somepassword"
   server-host = "http://localhost:8153/"
+  api-server-host = "http://localhost:8153/"
   webhookUrl = "https://hooks.slack.com/services/...."
 
   # optional fields
@@ -24,6 +25,7 @@ gocd.slack {
 - `login` - Login for a Go user who is authorized to access the REST API.
 - `password` - Password for the user specified above. You might want to create a less privileged user for this plugin.
 - `server-host` - FQDN of the Go Server. All links on the slack channel will be relative to this host.
+- `api-server-host` - This is an optional attribute. Set this field to localhost so server will use this endpoint to get `PipelineHistory` and `PipelineInstance`  
 - `webhookUrl` - Slack Webhook URL
 - `channel` - Override the default channel where we should send the notifications in slack. You can also give a value starting with `@` to send it to any specific user.
 

--- a/src/main/java/in/ashwanthkumar/gocd/slack/jsonapi/Server.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/jsonapi/Server.java
@@ -62,7 +62,7 @@ public class Server {
         throws MalformedURLException, IOException
     {
         URL url = new URL(String.format("%s/go/api/pipelines/%s/history",
-                mRules.getGoServerHost(), pipelineName));
+                mRules.getGoAPIServerHost(), pipelineName));
         JsonElement json = getUrl(url);
         return httpConnectionUtil.convertResponse(json, History.class);
     }
@@ -74,7 +74,7 @@ public class Server {
         throws MalformedURLException, IOException
     {
         URL url = new URL(String.format("%s/go/api/pipelines/%s/instance/%d",
-                                        mRules.getGoServerHost(), pipelineName, pipelineCounter));
+                                        mRules.getGoAPIServerHost(), pipelineName, pipelineCounter));
         JsonElement json = getUrl(url);
         return httpConnectionUtil.convertResponse(json, Pipeline.class);
     }

--- a/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/Rules.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/Rules.java
@@ -6,6 +6,7 @@ import in.ashwanthkumar.gocd.slack.PipelineListener;
 import in.ashwanthkumar.utils.collections.Lists;
 import in.ashwanthkumar.utils.func.Function;
 import in.ashwanthkumar.utils.func.Predicate;
+import in.ashwanthkumar.utils.lang.StringUtils;
 import in.ashwanthkumar.utils.lang.option.Option;
 
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ public class Rules {
     private String slackDisplayName;
     private String slackUserIconURL;
     private String goServerHost;
+    private String goAPIServerHost;
     private String goLogin;
     private String goPassword;
 
@@ -92,6 +94,19 @@ public class Rules {
         return this;
     }
 
+
+    public String getGoAPIServerHost() {
+        if (StringUtils.isNotEmpty(goAPIServerHost)) {
+            return goAPIServerHost;
+        }
+        return getGoServerHost();
+    }
+
+    public Rules setGoAPIServerHost(String goAPIServerHost) {
+        this.goAPIServerHost = goAPIServerHost;
+        return this;
+    }
+
     public String getGoLogin() {
         return goLogin;
     }
@@ -142,6 +157,10 @@ public class Rules {
         }
 
         String serverHost = config.getString("server-host");
+        String apiServerHost = null;
+        if (config.hasPath("api-server-host")) {
+            apiServerHost = config.getString("api-server-host");
+        }
         String login = null;
         if (config.hasPath("login")) {
             login = config.getString("login");
@@ -167,6 +186,7 @@ public class Rules {
                 .setSlackUserIcon(iconURL)
                 .setPipelineRules(pipelineRules)
                 .setGoServerHost(serverHost)
+                .setGoAPIServerHost(apiServerHost)
                 .setGoLogin(login)
                 .setGoPassword(password);
         try {

--- a/src/test/java/in/ashwanthkumar/gocd/slack/ruleset/RulesTest.java
+++ b/src/test/java/in/ashwanthkumar/gocd/slack/ruleset/RulesTest.java
@@ -95,6 +95,17 @@ public class RulesTest {
         assertThat(rules.find("p1", "s1", Status.Unknown.getStatus()).isDefined(), is(true));
     }
 
+    @Test
+    public void shouldGetAPIServerHost() {
+        Rules rules = new Rules();
+
+        rules.setGoServerHost("https://gocd.com");
+        assertThat(rules.getGoAPIServerHost(), is("https://gocd.com"));
+
+        rules.setGoAPIServerHost("http://localhost");
+        assertThat(rules.getGoAPIServerHost(), is("http://localhost"));
+    }
+
     private static PipelineRule pipelineRule(String pipeline, String stage, String channel, Set<PipelineStatus> statuses) {
         PipelineRule pipelineRule = new PipelineRule(pipeline, stage);
         pipelineRule.setStatus(statuses);


### PR DESCRIPTION
Added `api-server-host` optional attribute. So that server can use `localhost` instead of `fqdn` to call API.
