### PR TITLE
Fixes #58

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ gocd.slack {
 - `display-console-log-links` - Display console log links in the notification. Defaults to true, set to false if you want to hide.
 - `displayMaterialChanges` - Display material changes in the notification (git revisions for example). Defaults to true, set to false if you want to hide.
 - `process-all-rules` - If true, all matching rules are applied instead of just the first.
+- `truncate-changes` - If true, displays only the latest 5 changes for all the materials. (Default: true)
 - `proxy` - Specify proxy related settings for the plugin.
   - `proxy.hostname` - Proxy Host
   - `proxy.port` - Proxy Port

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ gocd.slack {
 - `display-console-log-links` - Display console log links in the notification. Defaults to true, set to false if you want to hide.
 - `displayMaterialChanges` - Display material changes in the notification (git revisions for example). Defaults to true, set to false if you want to hide.
 - `process-all-rules` - If true, all matching rules are applied instead of just the first.
+- `truncate-changes` - If true, displays only the latest 5 changes for all the materials. (Default: true)
 - `proxy` - Specify proxy related settings for the plugin.
   - `proxy.hostname` - Proxy Host
   - `proxy.port` - Proxy Port

--- a/src/main/java/in/ashwanthkumar/gocd/slack/SlackPipelineListener.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/SlackPipelineListener.java
@@ -23,7 +23,7 @@ import in.ashwanthkumar.utils.lang.StringUtils;
 import static in.ashwanthkumar.utils.lang.StringUtils.startsWith;
 
 public class SlackPipelineListener extends PipelineListener {
-    public static final int MAX_CHANGES_PER_MATERIAL_IN_SLACK = 5;
+    public static final int DEFAULT_MAX_CHANGES_PER_MATERIAL_IN_SLACK = 5;
     private Logger LOG = Logger.getLoggerFor(SlackPipelineListener.class);
 
     private final Slack slack;
@@ -113,8 +113,8 @@ public class SlackPipelineListener extends PipelineListener {
                 StringBuilder sb = new StringBuilder();
                 for (MaterialRevision change : changes) {
                     boolean isTruncated = false;
-                    if (change.modifications.size() > MAX_CHANGES_PER_MATERIAL_IN_SLACK) {
-                        change.modifications = Lists.take(change.modifications, MAX_CHANGES_PER_MATERIAL_IN_SLACK);
+                    if (rules.isTruncateChanges() && change.modifications.size() > DEFAULT_MAX_CHANGES_PER_MATERIAL_IN_SLACK) {
+                        change.modifications = Lists.take(change.modifications, DEFAULT_MAX_CHANGES_PER_MATERIAL_IN_SLACK);
                         isTruncated = true;
                     }
                     for (Modification mod : change.modifications) {
@@ -136,7 +136,7 @@ public class SlackPipelineListener extends PipelineListener {
                         }
                         sb.append("\n");
                     }
-                    String fieldNamePrefix = (isTruncated) ? String.format("Latest %d", MAX_CHANGES_PER_MATERIAL_IN_SLACK) : "All";
+                    String fieldNamePrefix = (isTruncated) ? String.format("Latest %d", DEFAULT_MAX_CHANGES_PER_MATERIAL_IN_SLACK) : "All";
                     String fieldName = String.format("%s changes for %s", fieldNamePrefix, change.material.description);
                     buildAttachment.addField(new SlackAttachment.Field(fieldName, sb.toString(), false));
                 }

--- a/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/Rules.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/Rules.java
@@ -32,6 +32,7 @@ public class Rules {
     private boolean displayConsoleLogLinks;
     private boolean displayMaterialChanges;
     private boolean processAllRules;
+    private boolean truncateChanges;
 
     private Proxy proxy;
 
@@ -159,6 +160,15 @@ public class Rules {
         return this;
     }
 
+    public boolean isTruncateChanges() {
+        return truncateChanges;
+    }
+
+    public Rules setTruncateChanges(boolean truncateChanges) {
+        this.truncateChanges = truncateChanges;
+        return this;
+    }
+
     public Proxy getProxy() {
         return proxy;
     }
@@ -240,6 +250,11 @@ public class Rules {
             processAllRules = config.getBoolean("process-all-rules");
         }
 
+        boolean truncateChanges = true;
+        if(config.hasPath("truncate-changes")) {
+            truncateChanges = config.getBoolean("truncate-changes");
+        }
+
         Proxy proxy = null;
         if (config.hasPath("proxy")) {
             Config proxyConfig = config.getConfig("proxy");
@@ -274,6 +289,7 @@ public class Rules {
                 .setDisplayConsoleLogLinks(displayConsoleLogLinks)
                 .setDisplayMaterialChanges(displayMaterialChanges)
                 .setProcessAllRules(processAllRules)
+                .setTruncateChanges(truncateChanges)
                 .setProxy(proxy);
         try {
             rules.pipelineListener = Class.forName(config.getString("listener")).asSubclass(PipelineListener.class).getConstructor(Rules.class).newInstance(rules);


### PR DESCRIPTION
Adding a new config 'truncate-changes', which is useful to display all changes or only latest 5 changes. See the issue #58  for more context.

@jdavisp3 Please have a look at this PR. 