### PR TITLE
Support for notifications based on pipeline group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ gocd.slack {
   pipelines = [{
     name = "gocd-slack-build"
     stage = "build"
+    group = ".*"
     state = "failed|passed"
     channel = "#oss-build-group"
     owners = ["ashwanthkumar"]
@@ -75,6 +76,7 @@ gocd.slack {
 `gocd.slack.pipelines` contains all the rules for the go-server. It is a list of rules (see below for what the parameters mean) for various pipelines. The plugin will pick the first matching pipeline rule from the pipelines collection above, so your most specific rule should be first, with the most generic rule at the bottom. Alternatively, set the `process-all-rules` option to `true` and all matching rules will be applied.
 - `name` - Regex to match the pipeline name
 - `stage` - Regex to match the stage name
+- `group` - Regex to match the pipeline group name
 - `state` - State of the pipeline at which we should send a notification. You can provide multiple values separated by pipe (`|`) symbol. Valid values are passed, failed, cancelled, building, fixed, broken or all.
 - `channel` - (Optional) channel where we should send the slack notification. This setting for a rule overrides the global setting
 - `owners` - (Optional) list of slack user handles who must be tagged in the message upon notifications

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ gocd.slack {
   pipelines = [{
     name = "gocd-slack-build"
     stage = "build"
+    group = ".*"
     state = "failed|passed"
     channel = "#oss-build-group"
     owners = ["ashwanthkumar"]
@@ -72,9 +73,10 @@ gocd.slack {
   }]
 }
 ```
-`gocd.slack.pipelines` contains all the rules for the go-server. It is a list of rules (see below for what the parameters mean) for various pipelines. The plugin will pick the first matching pipeline rule from the pipelines collection above, so your most specific rule should be first, with the most generic rule at the bottom.  Alternatively, set the `process-all-rules` option to `true` and all matching rules will be applied.
+`gocd.slack.pipelines` contains all the rules for the go-server. It is a list of rules (see below for what the parameters mean) for various pipelines. The plugin will pick the first matching pipeline rule from the pipelines collection above, so your most specific rule should be first, with the most generic rule at the bottom. Alternatively, set the `process-all-rules` option to `true` and all matching rules will be applied.
 - `name` - Regex to match the pipeline name
 - `stage` - Regex to match the stage name
+- `group` - Regex to match the pipeline group name
 - `state` - State of the pipeline at which we should send a notification. You can provide multiple values separated by pipe (`|`) symbol. Valid values are passed, failed, cancelled, building, fixed, broken or all.
 - `channel` - (Optional) channel where we should send the slack notification. This setting for a rule overrides the global setting
 - `owners` - (Optional) list of slack user handles who must be tagged in the message upon notifications

--- a/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationMessage.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationMessage.java
@@ -65,6 +65,9 @@ public class GoNotificationMessage {
         @SerializedName("counter")
         String counter;
 
+        @SerializedName("group")
+        String group;
+
         @SerializedName("stage")
         StageInfo stage;
 
@@ -118,6 +121,10 @@ public class GoNotificationMessage {
 
     public String getLastTransitionTime() {
         return pipeline.stage.lastTransitionTime;
+    }
+
+    public String getPipelineGroup() {
+        return pipeline.group;
     }
 
     /**

--- a/src/main/java/in/ashwanthkumar/gocd/slack/PipelineListener.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/PipelineListener.java
@@ -19,7 +19,7 @@ abstract public class PipelineListener {
     public void notify(GoNotificationMessage message) throws Exception {
         message.tryToFixStageResult(rules);
         LOG.debug(String.format("Finding rules with state %s", message.getStageResult()));
-        List<PipelineRule> foundRules = rules.find(message.getPipelineName(), message.getStageName(), message.getStageResult());
+        List<PipelineRule> foundRules = rules.find(message.getPipelineName(), message.getStageName(), message.getPipelineGroup(), message.getStageResult());
         if (foundRules.size() > 0) {
             for (PipelineRule pipelineRule : foundRules) {
                 LOG.debug(String.format("Matching rule is %s", pipelineRule));

--- a/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/Rules.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/Rules.java
@@ -182,10 +182,10 @@ public class Rules {
         return pipelineListener;
     }
 
-    public List<PipelineRule> find(final String pipeline, final String stage, final String pipelineStatus) {
+    public List<PipelineRule> find(final String pipeline, final String stage, final String group, final String pipelineStatus) {
         Predicate<PipelineRule> predicate = new Predicate<PipelineRule>() {
             public Boolean apply(PipelineRule input) {
-                return input.matches(pipeline, stage, pipelineStatus);
+                return input.matches(pipeline, stage, group, pipelineStatus);
             }
         };
 

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -3,7 +3,7 @@
     <about>
         <name>Slack Notification Plugin</name>
         <version>1.4.0-RC10</version>
-        <target-go-version>16.1.0</target-go-version>
+        <target-go-version>16.3.0</target-go-version>
         <description>Plugin to send build notifications to slack</description>
         <vendor>
             <name>Ashwanth Kumar</name>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -32,6 +32,7 @@ gocd.slack {
   default {
     name = ".*"
     stage = ".*"
+    group = ".*"
     # you can provide multiple values by separating them with | (pipe) symbol - failed|broken
     state = "broken|failed|fixed|cancelled" # accepted values - failed / broken / fixed / passed / cancelled / all
     #channel = "gocd"       # Mandatory field

--- a/src/test/java/in/ashwanthkumar/gocd/slack/ruleset/PipelineRuleTest.java
+++ b/src/test/java/in/ashwanthkumar/gocd/slack/ruleset/PipelineRuleTest.java
@@ -21,6 +21,7 @@ public class PipelineRuleTest {
         PipelineRule build = PipelineRule.fromConfig(config);
         assertThat(build.getNameRegex(), is(".*"));
         assertThat(build.getStageRegex(), is(".*"));
+        assertThat(build.getGroupRegex(), is(".*"));
         assertThat(build.getStatus(), hasItem(FAILED));
         assertThat(build.getChannel(), is("#gocd"));
         assertThat(build.getWebhookUrl(), is("https://hooks.slack.com/services/"));
@@ -37,6 +38,7 @@ public class PipelineRuleTest {
 
         PipelineRule mergedRule = PipelineRule.merge(build, defaultRule);
         assertThat(mergedRule.getNameRegex(), is("gocd-slack-build-notifier"));
+        assertThat(mergedRule.getGroupRegex(), is("ci"));
         assertThat(mergedRule.getStageRegex(), is("build"));
         assertThat(mergedRule.getStatus(), hasItem(FAILED));
         assertThat(mergedRule.getChannel(), is("#gocd"));
@@ -45,12 +47,12 @@ public class PipelineRuleTest {
 
     @Test
     public void shouldMatchThePipelineAndStageAgainstRegex() {
-        PipelineRule pipelineRule = new PipelineRule("gocd-.*", ".*").setStatus(Sets.of(FAILED, PASSED));
-        assertTrue(pipelineRule.matches("gocd-slack-build-notifier", "build", "failed"));
-        assertTrue(pipelineRule.matches("gocd-slack-build-notifier", "package", "passed"));
-        assertTrue(pipelineRule.matches("gocd-slack-build-notifier", "publish", "passed"));
+        PipelineRule pipelineRule = new PipelineRule("gocd-.*", ".*").setGroupRegex("ci").setStatus(Sets.of(FAILED, PASSED));
+        assertTrue(pipelineRule.matches("gocd-slack-build-notifier", "build", "ci", "failed"));
+        assertTrue(pipelineRule.matches("gocd-slack-build-notifier", "package", "ci", "passed"));
+        assertTrue(pipelineRule.matches("gocd-slack-build-notifier", "publish", "ci", "passed"));
 
-        assertFalse(pipelineRule.matches("gocd", "publish", "failed"));
+        assertFalse(pipelineRule.matches("gocd", "publish", "ci", "failed"));
     }
 
 

--- a/src/test/java/in/ashwanthkumar/gocd/slack/ruleset/RulesReaderTest.java
+++ b/src/test/java/in/ashwanthkumar/gocd/slack/ruleset/RulesReaderTest.java
@@ -25,6 +25,7 @@ public class RulesReaderTest {
         PipelineRule pipelineRule1 = new PipelineRule()
                 .setNameRegex("gocd-slack-build-notifier")
                 .setStageRegex(".*")
+                .setGroupRegex(".*")
                 .setChannel("#gocd")
                 .setStatus(Sets.of(PipelineStatus.FAILED));
         assertThat(rules.getPipelineRules(), hasItem(pipelineRule1));
@@ -32,6 +33,7 @@ public class RulesReaderTest {
         PipelineRule pipelineRule2 = new PipelineRule()
                 .setNameRegex("my-java-utils")
                 .setStageRegex("build")
+                .setGroupRegex("ci")
                 .setChannel("#gocd-build")
                 .setStatus(Sets.of(PipelineStatus.FAILED));
         assertThat(rules.getPipelineRules(), hasItem(pipelineRule2));
@@ -62,6 +64,7 @@ public class RulesReaderTest {
         PipelineRule pipelineRule = new PipelineRule()
                 .setNameRegex(".*")
                 .setStageRegex(".*")
+                .setGroupRegex(".*")
                 .setChannel("#build")
                 .setStatus(Sets.of(PipelineStatus.CANCELLED, PipelineStatus.BROKEN, PipelineStatus.FAILED, PipelineStatus.FIXED));
         assertThat(rules.getPipelineRules(), hasItem(pipelineRule));
@@ -81,6 +84,7 @@ public class RulesReaderTest {
         PipelineRule pipelineRule = new PipelineRule()
                 .setNameRegex(".*")
                 .setStageRegex(".*")
+                .setGroupRegex(".*")
                 .setChannel("#foo")
                 .setStatus(Sets.of(PipelineStatus.FAILED))
                 .setWebhookUrl("https://hooks.slack.com/services/for-pipeline");
@@ -102,6 +106,7 @@ public class RulesReaderTest {
         PipelineRule pipelineRule = new PipelineRule()
                 .setNameRegex(".*")
                 .setStageRegex(".*")
+                .setGroupRegex(".*")
                 .setChannel("#foo")
                 .setStatus(Sets.of(PipelineStatus.FAILED));
         assertThat(rules.getPipelineRules(), hasItem(pipelineRule));

--- a/src/test/java/in/ashwanthkumar/gocd/slack/ruleset/RulesTest.java
+++ b/src/test/java/in/ashwanthkumar/gocd/slack/ruleset/RulesTest.java
@@ -24,17 +24,17 @@ public class RulesTest {
                 pipelineRule("pipeline2", "stage2", "ch3", statuses(PipelineStatus.CANCELLED, PipelineStatus.BROKEN))
         ));
 
-        List<PipelineRule> foundRules1 = rules.find("pipeline1", "stage1", Status.Building.getStatus());
+        List<PipelineRule> foundRules1 = rules.find("pipeline1", "stage1", "ci", Status.Building.getStatus());
         assertThat(foundRules1.size(), is(1));
         assertThat(foundRules1.get(0).getNameRegex(), is("pipeline1"));
         assertThat(foundRules1.get(0).getStageRegex(), is("stage1"));
 
-        List<PipelineRule> foundRules2 = rules.find("pipeline2", "stage2", Status.Cancelled.getStatus());
+        List<PipelineRule> foundRules2 = rules.find("pipeline2", "stage2", "ci", Status.Cancelled.getStatus());
         assertThat(foundRules2.size(), is(1));
         assertThat(foundRules2.get(0).getNameRegex(), is("pipeline2"));
         assertThat(foundRules2.get(0).getStageRegex(), is("stage2"));
 
-        List<PipelineRule> foundRules3 = rules.find("pipeline2", "stage2", Status.Passed.getStatus());
+        List<PipelineRule> foundRules3 = rules.find("pipeline2", "stage2", "ci", Status.Passed.getStatus());
         assertThat(foundRules3.size(), is(0));
     }
 
@@ -49,27 +49,28 @@ public class RulesTest {
                 pipelineRule("\\d*", "[a-z]*", "ch4", statuses(PipelineStatus.BUILDING))
         ));
 
-        List<PipelineRule> foundRules1 = rules.find("abc", "efg", Status.Building.getStatus());
+        List<PipelineRule> foundRules1 = rules.find("abc", "efg", "ci", Status.Building.getStatus());
         assertThat(foundRules1.size(), is(1));
         assertThat(foundRules1.get(0).getNameRegex(), is("[a-z]*"));
         assertThat(foundRules1.get(0).getStageRegex(), is("[a-z]*"));
         assertThat(foundRules1.get(0).getChannel(), is("ch1"));
 
-        List<PipelineRule> foundRules2 = rules.find("123", "456", Status.Building.getStatus());
+        List<PipelineRule> foundRules2 = rules.find("123", "456", "ci", Status.Building.getStatus());
         assertThat(foundRules2.size(), is(1));
         assertThat(foundRules2.get(0).getNameRegex(), is("\\d*"));
         assertThat(foundRules2.get(0).getStageRegex(), is("\\d*"));
         assertThat(foundRules2.get(0).getChannel(), is("ch2"));
 
-        List<PipelineRule> foundRules3 = rules.find("123", "456", Status.Passed.getStatus());
+        List<PipelineRule> foundRules3 = rules.find("123", "456", "ci", Status.Passed.getStatus());
         assertThat(foundRules3.size(), is(1));
         assertThat(foundRules3.get(0).getNameRegex(), is("\\d*"));
         assertThat(foundRules3.get(0).getStageRegex(), is("\\d*"));
         assertThat(foundRules3.get(0).getChannel(), is("ch3"));
 
-        List<PipelineRule> foundRules4 = rules.find("pipeline1", "stage1", Status.Passed.getStatus());
+        List<PipelineRule> foundRules4 = rules.find("pipeline1", "stage1", "ci", Status.Passed.getStatus());
         assertThat(foundRules4.size(), is(0));
     }
+
     @Test
     public void shouldFindAllMatchesIfProcessAllRules() {
         Rules rules = new Rules();
@@ -80,16 +81,16 @@ public class RulesTest {
                 pipelineRule("[a-z]*", "stage2", "ch2", statuses(PipelineStatus.BUILDING))
         ));
 
-        List<PipelineRule> foundRules1 = rules.find("abc", "stage1", Status.Building.getStatus());
+        List<PipelineRule> foundRules1 = rules.find("abc", "stage1", "ci", Status.Building.getStatus());
         assertThat(foundRules1.size(), is(1));
         assertThat(foundRules1.get(0).getChannel(), is("ch1"));
 
-        List<PipelineRule> foundRules2 = rules.find("abc", "stage2", Status.Building.getStatus());
+        List<PipelineRule> foundRules2 = rules.find("abc", "stage2", "ci", Status.Building.getStatus());
         assertThat(foundRules2.size(), is(2));
         assertThat(foundRules2.get(0).getChannel(), is("ch1"));
         assertThat(foundRules2.get(1).getChannel(), is("ch2"));
 
-        List<PipelineRule> foundRules3 = rules.find("abc1", "stage2", Status.Building.getStatus());
+        List<PipelineRule> foundRules3 = rules.find("abc1", "stage2", "ci", Status.Building.getStatus());
         assertThat(foundRules3.size(), is(0));
     }
 
@@ -101,14 +102,14 @@ public class RulesTest {
                 pipelineRule("p1", "s1", "ch1", statuses(PipelineStatus.ALL))
         ));
 
-        assertThat(rules.find("p1", "s1", Status.Building.getStatus()).size(), is(1));
-        assertThat(rules.find("p1", "s1", Status.Broken.getStatus()).size(), is(1));
-        assertThat(rules.find("p1", "s1", Status.Cancelled.getStatus()).size(), is(1));
-        assertThat(rules.find("p1", "s1", Status.Failed.getStatus()).size(), is(1));
-        assertThat(rules.find("p1", "s1", Status.Failing.getStatus()).size(), is(1));
-        assertThat(rules.find("p1", "s1", Status.Fixed.getStatus()).size(), is(1));
-        assertThat(rules.find("p1", "s1", Status.Passed.getStatus()).size(), is(1));
-        assertThat(rules.find("p1", "s1", Status.Unknown.getStatus()).size(), is(1));
+        assertThat(rules.find("p1", "s1", "ci", Status.Building.getStatus()).size(), is(1));
+        assertThat(rules.find("p1", "s1", "ci", Status.Broken.getStatus()).size(), is(1));
+        assertThat(rules.find("p1", "s1", "ci", Status.Cancelled.getStatus()).size(), is(1));
+        assertThat(rules.find("p1", "s1", "ci", Status.Failed.getStatus()).size(), is(1));
+        assertThat(rules.find("p1", "s1", "ci", Status.Failing.getStatus()).size(), is(1));
+        assertThat(rules.find("p1", "s1", "ci", Status.Fixed.getStatus()).size(), is(1));
+        assertThat(rules.find("p1", "s1", "ci", Status.Passed.getStatus()).size(), is(1));
+        assertThat(rules.find("p1", "s1", "ci", Status.Unknown.getStatus()).size(), is(1));
     }
 
     @Test

--- a/src/test/resources/configs/default-pipeline-rule.conf
+++ b/src/test/resources/configs/default-pipeline-rule.conf
@@ -1,5 +1,6 @@
 pipeline {
   name = "defaultRule"
+  group = "ci"
   stage = "build"
   # you can provide multiple values by separating them with | (pipe) symbol - failed|broken
   state = "failed"        # accepted values - failed / broken / fixed / passed / all

--- a/src/test/resources/configs/go_notify.conf
+++ b/src/test/resources/configs/go_notify.conf
@@ -12,6 +12,7 @@ gocd.slack {
   default {
     name = ".*"
     stage = ".*"
+    group = ".*"
     # you can provide multiple values by separating them with | (pipe) symbol - failed|broken
     state = "failed"        # accepted values - failed / broken / fixed / passed / all
     #channel = "gocd"       # Mandatory field

--- a/src/test/resources/configs/pipeline-rule-1.conf
+++ b/src/test/resources/configs/pipeline-rule-1.conf
@@ -1,6 +1,7 @@
 pipeline {
   name = ".*"
   stage = ".*"
+  group = ".*"
   # you can provide multiple values by separating them with | (pipe) symbol - failed|broken
   state = "failed"        # accepted values - failed / broken / fixed / passed / all
   channel = "#gocd"       # optional field

--- a/src/test/resources/configs/test-config-1.conf
+++ b/src/test/resources/configs/test-config-1.conf
@@ -18,6 +18,7 @@ gocd.slack {
   default {
     name = ".*"
     stage = ".*"
+    group = ".*"
     # you can provide multiple values by separating them with | (pipe) symbol - failed|broken
     state = "failed"        # accepted values - failed / broken / fixed / passed / all
     #channel = "gocd"       # Mandatory field
@@ -34,6 +35,7 @@ gocd.slack {
   }, {
     name = "my-java-utils"
     stage = "build"
+    group = "ci"
     # you can provide multiple values by separating them with | (pipe) symbol - failed|broken
     state = "failed"        # accepted values - failed / broken / fixed / passed / all
     channel = "#gocd-build"       # Mandatory field


### PR DESCRIPTION
Fixes #65 

Major changes
1. Updating the min GoCD support to 16.3.0. Given that's the oldest [plugin API documentation](https://plugin-api.go.cd/16.3.0/notifications/#stage-status-changed) available online that seems to support pipeline group names. 
2. `RulesTest.java` has lot of changes because I changed the line encodings from windows format to Linux format. 

@jdavisp3 Please review this for me when you've time. 
cc: @ByteFlinger
