### PR TITLE
Bump version on plugin.xml

### DIFF
--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -2,7 +2,7 @@
 <go-plugin id="slack.notifier" version="1">
     <about>
         <name>Slack Notification Plugin</name>
-        <version>1.4.0-RC11</version>
+        <version>1.4.0-12</version>
         <target-go-version>16.3.0</target-go-version>
         <description>Plugin to send build notifications to slack</description>
         <vendor>

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -2,7 +2,7 @@
 <go-plugin id="slack.notifier" version="1">
     <about>
         <name>Slack Notification Plugin</name>
-        <version>1.4.0-12</version>
+        <version>1.4.0</version>
         <target-go-version>16.3.0</target-go-version>
         <description>Plugin to send build notifications to slack</description>
         <vendor>


### PR DESCRIPTION
The version reported in the GoCD plugin administration page reports an incorrect version. This change fixes it to be in alignment with the current release.