### PR TITLE
Add support for MS Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,33 @@ gocd.slack {
   - `proxy.port` - Proxy Port
   - `proxy.type` - `socks` or `http` are the only accepted values.
 
+### Teams Configuration
+
+To send notifications to Microsoft Teams instead of Slack you need to configure the `listener` setting as shown in the example below.
+The other difference is that the channel setting is not used,
+instead with Teams you create an incoming webhook for each channel you want to send messages to.
+
+```hocon
+gocd.slack {
+  # Tell the plugin you are using Microsoft Teams instead of Slack.
+  listener = "in.ashwanthkumar.gocd.teams.TeamsPipelineListener"
+  
+  # Determines the Team and Channel to send notifications to unless overridden by a pipeline rule.
+  webhookUrl = "https://xxx.webhook.office.com/webhookb2/xxx/IncomingWebhook/xxx/xxx"
+  
+  # The channel setting is not used, only the webhookUrl.
+  
+  pipelines = [{
+    # The channel setting is ignored.
+    
+    # Optionally override the default webhook to send notifications to a different channel.
+    webhookUrl = "https://example.com"
+    
+    # The rest of the configuration functions the same.
+  },
+}
+```
+
 ## Pipeline Rules
 By default the plugin pushes a note about all failed stages across all pipelines to Slack. You have fine grain control over this operation.
 ```hocon

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>in.ashwanthkumar</groupId>
     <artifactId>gocd-slack-notifier</artifactId>
-    <version>2.0.2</version>
+    <version>2.1.0-beta</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationMessage.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/GoNotificationMessage.java
@@ -221,4 +221,18 @@ public class GoNotificationMessage {
             server.getPipelineInstance(pipeline.name, Integer.parseInt(pipeline.counter));
         return pipelineInstance.rootChanges(server);
     }
+
+    public Stage pickCurrentStage(Stage[] stages) {
+        for (Stage stage : stages) {
+            if (getStageName().equals(stage.name)) {
+                return stage;
+            }
+        }
+        throw new IllegalArgumentException("The list of stages from the pipeline ("
+                + getPipelineName()
+                + ") doesn't have the active stage ("
+                + getStageName()
+                + ") for which we got the notification.");
+    }
+
 }

--- a/src/main/java/in/ashwanthkumar/gocd/slack/PipelineListener.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/PipelineListener.java
@@ -9,7 +9,7 @@ import in.ashwanthkumar.utils.lang.option.Option;
 import java.util.List;
 
 abstract public class PipelineListener {
-    private Logger LOG = Logger.getLoggerFor(PipelineListener.class);
+    private static final Logger LOG = Logger.getLoggerFor(PipelineListener.class);
     protected Rules rules;
 
     public PipelineListener(Rules rules) {

--- a/src/main/java/in/ashwanthkumar/gocd/slack/SlackPipelineListener.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/SlackPipelineListener.java
@@ -23,7 +23,7 @@ import static in.ashwanthkumar.utils.lang.StringUtils.startsWith;
 
 public class SlackPipelineListener extends PipelineListener {
     public static final int DEFAULT_MAX_CHANGES_PER_MATERIAL_IN_SLACK = 5;
-    private Logger LOG = Logger.getLoggerFor(SlackPipelineListener.class);
+    private static final Logger LOG = Logger.getLoggerFor(SlackPipelineListener.class);
 
     private final Slack slack;
 
@@ -79,7 +79,7 @@ public class SlackPipelineListener extends PipelineListener {
     }
 
     private SlackAttachment slackAttachment(PipelineRule rule, GoNotificationMessage message, PipelineStatus pipelineStatus) throws URISyntaxException {
-        String title = String.format("Stage [%s] %s %s", message.fullyQualifiedJobName(), verbFor(pipelineStatus), pipelineStatus).replaceAll("\\s+", " ");
+        String title = String.format("Stage [%s] %s %s", message.fullyQualifiedJobName(), pipelineStatus.verb(), pipelineStatus).replaceAll("\\s+", " ");
         SlackAttachment buildAttachment = new SlackAttachment("")
                 .fallback(title)
                 .title(title, message.goServerUrl(rules.getGoServerHost()));
@@ -188,22 +188,6 @@ public class SlackPipelineListener extends PipelineListener {
         }
 
         throw new IllegalArgumentException("The list of stages from the pipeline (" + message.getPipelineName() + ") doesn't have the active stage (" + message.getStageName() + ") for which we got the notification.");
-    }
-
-    private String verbFor(PipelineStatus pipelineStatus) {
-        switch (pipelineStatus) {
-            case BROKEN:
-            case FIXED:
-            case BUILDING:
-                return "is";
-            case FAILED:
-            case PASSED:
-                return "has";
-            case CANCELLED:
-                return "was";
-            default:
-                return "";
-        }
     }
 
     private void updateSlackChannel(String slackChannel) {

--- a/src/main/java/in/ashwanthkumar/gocd/slack/SlackPipelineListener.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/SlackPipelineListener.java
@@ -88,7 +88,7 @@ public class SlackPipelineListener extends PipelineListener {
         // Describe the build.
         try {
             Pipeline details = message.fetchDetails(rules);
-            Stage stage = pickCurrentStage(details.stages, message);
+            Stage stage = message.pickCurrentStage(details.stages);
             buildAttachment.addField(new SlackAttachment.Field("Triggered by", stage.approvedBy, true));
             if (details.buildCause.triggerForced) {
                 buildAttachment.addField(new SlackAttachment.Field("Reason", "Manual Trigger", true));
@@ -178,16 +178,6 @@ public class SlackPipelineListener extends PipelineListener {
             consoleLinks.add("<" + link.normalize().toASCIIString() + "| View " + job + " logs>");
         }
         return consoleLinks;
-    }
-
-    private Stage pickCurrentStage(Stage[] stages, GoNotificationMessage message) {
-        for (Stage stage : stages) {
-            if (message.getStageName().equals(stage.name)) {
-                return stage;
-            }
-        }
-
-        throw new IllegalArgumentException("The list of stages from the pipeline (" + message.getPipelineName() + ") doesn't have the active stage (" + message.getStageName() + ") for which we got the notification.");
     }
 
     private void updateSlackChannel(String slackChannel) {

--- a/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/PipelineStatus.java
+++ b/src/main/java/in/ashwanthkumar/gocd/slack/ruleset/PipelineStatus.java
@@ -81,6 +81,22 @@ public enum PipelineStatus {
         }
     };
 
+    public String verb() {
+        switch (this) {
+            case BROKEN:
+            case FIXED:
+            case BUILDING:
+                return "is";
+            case FAILED:
+            case PASSED:
+                return "has";
+            case CANCELLED:
+                return "was";
+            default:
+                return "";
+        }
+    }
+
     public boolean matches(String state) {
         return this == ALL || this == PipelineStatus.valueOf(state.toUpperCase());
     }

--- a/src/main/java/in/ashwanthkumar/gocd/teams/CardHttpContent.java
+++ b/src/main/java/in/ashwanthkumar/gocd/teams/CardHttpContent.java
@@ -1,0 +1,27 @@
+package in.ashwanthkumar.gocd.teams;
+
+import com.google.api.client.http.AbstractHttpContent;
+import com.google.api.client.json.Json;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+
+/**
+ * Serialize a {@link TeamsCard} for the Google HTTP Client.
+ */
+public class CardHttpContent extends AbstractHttpContent {
+    private final TeamsCard card;
+
+    protected CardHttpContent(TeamsCard card) {
+        super(Json.MEDIA_TYPE);
+        this.card = card;
+    }
+
+    @Override
+    public void writeTo(OutputStream out) throws IOException {
+        try (var osw = new OutputStreamWriter(out)) {
+            osw.write(card.toString());
+        }
+    }
+}

--- a/src/main/java/in/ashwanthkumar/gocd/teams/MessageCardSchema.java
+++ b/src/main/java/in/ashwanthkumar/gocd/teams/MessageCardSchema.java
@@ -1,0 +1,89 @@
+package in.ashwanthkumar.gocd.teams;
+
+import com.google.gson.annotations.SerializedName;
+import in.ashwanthkumar.gocd.slack.ruleset.PipelineStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * These objects create the MessageCard JSON sent to Teams using {@link com.google.gson.Gson}.
+ * More details:
+ * https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference
+ */
+public class MessageCardSchema {
+    @SerializedName("@type")
+    String type = "MessageCard";
+    String themeColor = Color.NONE.getHexCode();
+    String title = "";
+    /**
+     * Not sure what this does, but a summary or text field is required.
+     */
+    String summary = "GoCD build update";
+    List<FactSection> sections = new ArrayList<>();
+    List<Object> potentialAction = new ArrayList<>();
+
+    public enum Color {
+        NONE(""),
+        RED("990000"),
+        GREEN("009900");
+
+        private final String hexCode;
+
+        Color(String hexCode) {
+            this.hexCode = hexCode;
+        }
+
+        public static Color findColor(PipelineStatus status) {
+            switch (status) {
+                case PASSED:
+                case FIXED:
+                    return Color.GREEN;
+                case FAILED:
+                case BROKEN:
+                    return Color.RED;
+                default:
+                    return Color.NONE;
+            }
+        }
+
+        public String getHexCode() {
+            return this.hexCode;
+        }
+    }
+
+    public static class Fact {
+        String name = "";
+        String value = "";
+
+        public Fact(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+    }
+
+    public static class FactSection {
+        List<Fact> facts = new ArrayList<>();
+    }
+
+    public static class OpenUriAction {
+        @SerializedName("@type")
+        String type = "OpenUri";
+        String name = "";
+        List<Target> targets = new ArrayList<>();
+
+        public OpenUriAction(String name, String uri) {
+            this.name = name;
+            this.targets.add(new MessageCardSchema.Target(uri));
+        }
+    }
+
+    public static class Target {
+        String os = "default";
+        String uri = "";
+
+        public Target(String uri) {
+            this.uri = uri;
+        }
+    }
+}

--- a/src/main/java/in/ashwanthkumar/gocd/teams/TeamsCard.java
+++ b/src/main/java/in/ashwanthkumar/gocd/teams/TeamsCard.java
@@ -1,0 +1,36 @@
+package in.ashwanthkumar.gocd.teams;
+
+import com.google.gson.Gson;
+
+/**
+ * Populate the values of a Message Card for Teams.
+ */
+public class TeamsCard {
+    private final MessageCardSchema.FactSection factSection = new MessageCardSchema.FactSection();
+    private final MessageCardSchema schema = new MessageCardSchema();
+
+    public TeamsCard() {
+        this.schema.sections.add(this.factSection);
+    }
+
+    public void setTitle(String title) {
+        this.schema.title = title;
+    }
+
+    public void addFact(String name, String value) {
+        this.factSection.facts.add(new MessageCardSchema.Fact(name, value));
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(schema);
+    }
+
+    public void setColor(MessageCardSchema.Color color) {
+        this.schema.themeColor = color.getHexCode();
+    }
+
+    public void addLinkAction(String name, String uri) {
+        this.schema.potentialAction.add(new MessageCardSchema.OpenUriAction(name, uri));
+    }
+}

--- a/src/main/java/in/ashwanthkumar/gocd/teams/TeamsPipelineListener.java
+++ b/src/main/java/in/ashwanthkumar/gocd/teams/TeamsPipelineListener.java
@@ -1,0 +1,90 @@
+package in.ashwanthkumar.gocd.teams;
+
+import com.thoughtworks.go.plugin.api.logging.Logger;
+import in.ashwanthkumar.gocd.slack.GoNotificationMessage;
+import in.ashwanthkumar.gocd.slack.PipelineListener;
+import in.ashwanthkumar.gocd.slack.jsonapi.Pipeline;
+import in.ashwanthkumar.gocd.slack.jsonapi.Stage;
+import in.ashwanthkumar.gocd.slack.ruleset.PipelineRule;
+import in.ashwanthkumar.gocd.slack.ruleset.PipelineStatus;
+import in.ashwanthkumar.gocd.slack.ruleset.Rules;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * To enable this for Teams support add the following line to your config:
+ * listener = "in.ashwanthkumar.gocd.teams.TeamsPipelineListener"
+ *
+ * @see in.ashwanthkumar.gocd.slack.SlackPipelineListener
+ */
+public class TeamsPipelineListener extends PipelineListener {
+    private static final Logger LOG = Logger.getLoggerFor(TeamsPipelineListener.class);
+    private final TeamsWebhook teams;
+
+    public TeamsPipelineListener(Rules rules) {
+        super(rules);
+        teams = new TeamsWebhook(rules.getProxy());
+    }
+
+    private String getWebhook(PipelineRule rule) {
+        final String ruleWebhook = rule.getWebhookUrl();
+        if (ruleWebhook != null && !ruleWebhook.isEmpty()) {
+            return ruleWebhook;
+        } else {
+            return this.rules.getWebHookUrl();
+        }
+    }
+
+    private void sendMessage(PipelineRule rule, GoNotificationMessage message, PipelineStatus status)
+            throws GoNotificationMessage.BuildDetailsNotFoundException, URISyntaxException, IOException {
+        final TeamsCard card = new TeamsCard();
+        card.setColor(MessageCardSchema.Color.findColor(status));
+        card.addLinkAction("Details", message.goServerUrl(rules.getGoServerHost()));
+        card.setTitle(String.format("Stage [%s] %s %s",
+                        message.fullyQualifiedJobName(),
+                        status.verb(),
+                        status)
+                .replaceAll("\\s+", " "));
+
+        Pipeline details = message.fetchDetails(rules);
+        Stage stage = message.pickCurrentStage(details.stages);
+
+        card.addFact("Triggered by", stage.approvedBy);
+        card.addFact("Reason", details.buildCause.triggerMessage);
+        card.addFact("Label", details.label);
+
+        teams.send(getWebhook(rule), card);
+    }
+
+
+    @Override
+    public void onBuilding(PipelineRule rule, GoNotificationMessage message) throws Exception {
+        sendMessage(rule, message, PipelineStatus.BUILDING);
+    }
+
+    @Override
+    public void onPassed(PipelineRule rule, GoNotificationMessage message) throws Exception {
+        sendMessage(rule, message, PipelineStatus.PASSED);
+    }
+
+    @Override
+    public void onFailed(PipelineRule rule, GoNotificationMessage message) throws Exception {
+        sendMessage(rule, message, PipelineStatus.FAILED);
+    }
+
+    @Override
+    public void onBroken(PipelineRule rule, GoNotificationMessage message) throws Exception {
+        sendMessage(rule, message, PipelineStatus.BROKEN);
+    }
+
+    @Override
+    public void onFixed(PipelineRule rule, GoNotificationMessage message) throws Exception {
+        sendMessage(rule, message, PipelineStatus.FIXED);
+    }
+
+    @Override
+    public void onCancelled(PipelineRule rule, GoNotificationMessage message) throws Exception {
+        sendMessage(rule, message, PipelineStatus.CANCELLED);
+    }
+}

--- a/src/main/java/in/ashwanthkumar/gocd/teams/TeamsWebhook.java
+++ b/src/main/java/in/ashwanthkumar/gocd/teams/TeamsWebhook.java
@@ -1,0 +1,38 @@
+package in.ashwanthkumar.gocd.teams;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.thoughtworks.go.plugin.api.logging.Logger;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.util.Objects;
+
+/**
+ * Sends post requests to a Teams channels incoming webhook.
+ * Uses Google HTTP Client.
+ */
+public class TeamsWebhook {
+    private static final Logger LOG = Logger.getLoggerFor(TeamsWebhook.class);
+    private final HttpRequestFactory requestFactory;
+
+    public TeamsWebhook(Proxy proxy) {
+        requestFactory = new NetHttpTransport.Builder()
+                .setProxy(proxy)
+                .build()
+                .createRequestFactory();
+    }
+
+    public void send(String webhookUrl, TeamsCard card) throws IOException {
+        Objects.requireNonNull(webhookUrl);
+        Objects.requireNonNull(card);
+        LOG.debug("Using webhook: " + webhookUrl);
+        LOG.debug("Sending Card: " + card);
+        requestFactory.buildPostRequest(
+                        new GenericUrl(webhookUrl),
+                        new CardHttpContent(card)
+                )
+                .execute();
+    }
+}

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -2,7 +2,7 @@
 <go-plugin id="slack.notifier" version="1">
     <about>
         <name>Slack Notification Plugin</name>
-        <version>2.0.2</version>
+        <version>2.1.0-beta</version>
         <target-go-version>20.1.0</target-go-version>
         <description>Plugin to send build notifications to slack</description>
         <vendor>

--- a/src/test/java/in/ashwanthkumar/gocd/slack/ruleset/PipelineRuleTest.java
+++ b/src/test/java/in/ashwanthkumar/gocd/slack/ruleset/PipelineRuleTest.java
@@ -2,7 +2,6 @@ package in.ashwanthkumar.gocd.slack.ruleset;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import in.ashwanthkumar.utils.collections.Lists;
 import in.ashwanthkumar.utils.collections.Sets;
 import org.junit.Test;
 

--- a/src/test/java/in/ashwanthkumar/gocd/teams/TeamsTest.java
+++ b/src/test/java/in/ashwanthkumar/gocd/teams/TeamsTest.java
@@ -1,0 +1,43 @@
+package in.ashwanthkumar.gocd.teams;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class TeamsTest {
+
+    private TeamsCard buildCard() {
+        TeamsCard card = new TeamsCard();
+        card.setTitle("title");
+        card.setColor(MessageCardSchema.Color.GREEN);
+        card.addFact("k", "v");
+        card.addLinkAction("name", "uri");
+        return card;
+    }
+
+    @Test
+    public void testCardHttpContent() throws IOException {
+        TeamsCard card = buildCard();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new CardHttpContent(card).writeTo(baos);
+        final String result = baos.toString();
+
+        Assert.assertEquals(card.toString(), result);
+    }
+
+    @Test
+    public void testCardToString() {
+        TeamsCard card = buildCard();
+        String result = card.toString();
+
+        String expected = ("{'@type':'MessageCard','themeColor':'009900','title':'title'," +
+                "'summary':'GoCD build update','sections':[{'facts':[{'name':'k'," +
+                "'value':'v'}]}],'potentialAction':[{'@type':'OpenUri','name':'name'," +
+                "'targets':[{'os':'default','uri':'uri'}]}]}")
+                .replace('\'', '"');
+
+        Assert.assertEquals(expected, result);
+    }
+}

--- a/src/test/java/in/ashwanthkumar/gocd/teams/TeamsTest.java
+++ b/src/test/java/in/ashwanthkumar/gocd/teams/TeamsTest.java
@@ -1,5 +1,8 @@
 package in.ashwanthkumar.gocd.teams;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import in.ashwanthkumar.gocd.slack.ruleset.Rules;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -39,5 +42,18 @@ public class TeamsTest {
                 .replace('\'', '"');
 
         Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void testTeamsListener() {
+        Config config = ConfigFactory.parseResources("configs/test-config-teams.conf")
+                .withFallback(ConfigFactory.load(getClass().getClassLoader()))
+                .getConfig("gocd.slack");
+        Rules rules = Rules.fromConfig(config);
+
+        Assert.assertEquals(TeamsPipelineListener.class, rules.getPipelineListener().getClass());
+        Assert.assertEquals("https://example.com/default", rules.getWebHookUrl());
+        Assert.assertEquals("https://example.com/pipeline-override",
+                rules.getPipelineRules().get(0).getWebhookUrl());
     }
 }

--- a/src/test/resources/configs/test-config-teams.conf
+++ b/src/test/resources/configs/test-config-teams.conf
@@ -1,0 +1,17 @@
+gocd.slack {
+  login = "foo"
+  password = "foo-bar"
+  server-host = "https://go-instance:8153/"
+
+  # Teams specific configuration
+  listener = "in.ashwanthkumar.gocd.teams.TeamsPipelineListener"
+  webhookUrl = "https://example.com/default"
+
+  pipelines = [{
+    name = ".*"
+    stage = ".*"
+    state = "failed"
+    # Optionally send these messages to another channel using a different webhook.
+    webhookUrl = "https://example.com/pipeline-override"
+  }]
+}


### PR DESCRIPTION
This PR adds a `TeamsPipelineListener` which can be used to send notifications to Microsoft Teams instead of Slack.

Teams uses a unique incoming webhook for each channel, otherwise, the rest of the configuration is the same.

Note, I bumped the version to `2.1.0-beta` for my own testing. We are currently running this branch in production with many pipelines, webhooks, and builds.

FYI @jdavisp3 